### PR TITLE
feat: 포트폴리오 api/store 추가 & 요청 인터셉터 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2322,9 +2322,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.7.0-beta.1",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.7.0-beta.1.tgz",
-      "integrity": "sha512-F6a+pSG7dLrU28sGlR8r4WMuBsLMprOsDpaywGopNrGk351Hs4AAhx/y88ROGUEf28yAPShSM86bPnD30xNyDw==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.7.2.tgz",
+      "integrity": "sha512-q0WTcRG977+a9Dqhb8TOaPm+Xmvj0oVhnBJhAdHWFSov3HhHTTxlH2nXP/GBTXZuuMHDbBeIWFuUR2/1Fx0PPw==",
       "dev": true,
       "engines": {
         "node": "^12.20 || >=14.13"
@@ -2337,7 +2337,6 @@
         "typescript": ">=4.7",
         "vite-plugin-vuetify": ">=1.0.0",
         "vue": "^3.3.0",
-        "vue-i18n": "^9.0.0",
         "webpack-plugin-vuetify": ">=2.0.0"
       },
       "peerDependenciesMeta": {
@@ -2345,9 +2344,6 @@
           "optional": true
         },
         "vite-plugin-vuetify": {
-          "optional": true
-        },
-        "vue-i18n": {
           "optional": true
         },
         "webpack-plugin-vuetify": {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,21 +1,61 @@
 import axios from 'axios';
 
-import router from '@/router';
-
 const instance = axios.create({
+    baseURL: 'http://localhost:8080/api',
+    headers: {
+        'Content-Type': 'application/json',
+    },
     timeout: 5000,
 });
 
+// 요청 인터셉터
+instance.interceptors.request.use(
+    (config) => {
+        // 쿠키에서 Refresh-Token 추출
+        const cookies = document.cookie.split('; ').reduce((acc, cookie) => {
+            const [name, value] = cookie.split('=');
+            acc[name] = decodeURIComponent(value); // URL 디코딩
+            return acc;
+        }, {});
+
+        const token = cookies['Refresh-Token']; // 쿠키에서 'Refresh-Token' 가져오기
+        if (token) {
+            // 토큰이 있는 경우
+            config.headers['Authorization'] = `Bearer ${token}`;
+            console.log(config.headers.Authorization);
+        }
+        return config;
+    },
+    (error) => {
+        console.log(error);
+        return Promise.reject(error);
+    }
+);
+
+// 응답 인터셉터
 instance.interceptors.response.use(
     (response) => {
         if (response.status === 200) {
             return response;
         }
-        if (response.status === 400) {
-            return Promise.reject('404: 페이지 없음' + response.request);
+        if (response.status === 404) {
+            return Promise.reject('404: 페이지 없음 ' + response.request);
         }
         return response;
-    }
+    },
+    // 로그아웃이나 admin 기능 추가시 설정 필요!!!
+    // async (error) => {
+    //     if (error.response?.status === 401) {
+    //         const { logout } = useAuthStore();
+    //         logout();
+    //         router.push('/auth/login?error=loing_required');
+    //         return Promise.reject({ error: '로그인이 필요한 서비스입니다.' });
+    //         // 로그인 필요
+    //     } else if (error.response?.status === 403) {
+    //         return Promise.reject({ error: '권한이 부족합니다.' });
+    //     }
+    //     return Promise.reject(error);
+    // }
 );
 
 export default instance;

--- a/src/api/portfolio.js
+++ b/src/api/portfolio.js
@@ -1,0 +1,48 @@
+import axios from "axios";
+import instance from "@/api/index.js";
+
+// const portfolioApi = axios.create({
+//     baseURL: 'http://localhost:8080/api/portfolio', // API 엔드 포인트
+//     headers: {
+//         'Content-Type': 'application/json',
+//     },
+// });
+
+export async function fetchPortfolioList() {
+    try {
+        const response = await instance.get('/portfolio/list');
+        return response.data;
+    } catch (error) {
+        console.error('Error fetching portfolio list:', error);
+        throw error; // 오류 발생 시 오류를 던져줌
+    }
+}
+
+export async function getPortfolioDetail(portfolioId) {
+    try {
+        const response = await instance.get(`/portfolio/details/${portfolioId}`);
+        return response.data;
+    } catch (error) {
+        console.error('Error fetching portfolio detail:', error);
+        throw error; // 오류 발생 시 오류를 던져줌
+    }
+}
+
+export async function postPortfolio(portfolioReqDto) {
+    try {
+        const response = await instance.post('/portfolio', portfolioReqDto);
+        return response.data;
+    } catch (error) {
+        console.error('Error posting portfolio:', error);
+        throw error; // 오류 발생 시 오류를 던져줌
+    }
+}
+
+export async function deletePortfolio(portfolioId) {
+    try {
+        await instance.delete(`/portfolio/${portfolioId}`);
+    } catch (error) {
+        console.error('Error deleting portfolio:', error);
+        throw error; // 오류 발생 시 오류를 던져줌
+    }
+}

--- a/src/api/portfolio.js
+++ b/src/api/portfolio.js
@@ -1,4 +1,3 @@
-import axios from "axios";
 import instance from "@/api/index.js";
 
 // const portfolioApi = axios.create({

--- a/src/api/portfolioApi.js
+++ b/src/api/portfolioApi.js
@@ -1,8 +1,0 @@
-import axios from 'axios';
-
-const userApi = axios.create({
-  baseURL: 'http://localhost:8080/api/portfolio', // 사용자 API 엔드포인트
-  headers: {
-    'Content-Type': 'application/json',
-  },
-});

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -42,6 +42,7 @@ import CartItem from '@/views/cart/CartItem.vue';
 import recentViewed from "@/views/recentView/recentView.vue";
 import recentView from "@/views/recentView/recentView.vue";
 import portfolioData from "@/views/portfolio/PortfolioData.vue";
+import portfolioEx from "@/views/portfolio/PortfolioEx.vue";
 
 
 const routes = [
@@ -86,6 +87,7 @@ const routes = [
     { path: '/cart-item', name: 'CartItem', component: CartItem },
     { path: '/recent-view', name: 'RecentView', component: recentView },
     { path: '/portfolio-data', name: 'portfolioData', component: portfolioData },
+    { path: '/portfolio-ex', name: 'portfolioEx', component: portfolioEx },
 ];
 
 const router = createRouter({

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -3,6 +3,7 @@ import bondModule from "./modules/bond";
 import fundModule from "./modules/fund";
 import savingModule from "./modules/saving";
 import depositModule from "./modules/deposit";
+import portfolioModule from "./modules/portfolio";
 
 const store = createStore({
   modules: {
@@ -10,6 +11,7 @@ const store = createStore({
     fund: fundModule,
     saving: savingModule,
     deposit: depositModule,
+    portfolio: portfolioModule,
   },
 });
 

--- a/src/store/modules/portfolio.js
+++ b/src/store/modules/portfolio.js
@@ -1,0 +1,83 @@
+import { fetchPortfolioList, getPortfolioDetail, postPortfolio, deletePortfolio } from '@/api/portfolio.js';
+
+const portfolioModule = {
+    namespaced: true,
+    state: () => ({
+        portfolioList: [],
+        portfolioListLoaded: false,
+        portfolioDetail: null,
+        newPortfolio: null,
+        newPortfolioItems: [],
+    }),
+
+    actions: {
+        async fetchPortfolioList({ commit, state }) {
+            if(!state.portfolioListLoaded) {
+                try {
+                    const data = await fetchPortfolioList();
+                    commit('setPortfolioList', data);
+                } catch (error) {
+                    console.error('Error fetching portfolio list:', error);
+                }
+            }
+        },
+
+        async getPortfolioDetail({ commit }, portfolioId) {
+            try {
+                const data = await getPortfolioDetail(portfolioId);
+                commit('setPortfolioDetail', data);
+            } catch (error) {
+                console.error('Error fetching portfolio detail:', error);
+            }
+        },
+
+        async postPortfolio({ commit }, portfolio) {
+            try {
+                const data = await postPortfolio(portfolio);
+                commit('setNewPortfolio', data);
+            } catch (error) {
+                console.error('Error posting portfolio:', error);
+            }
+        },
+
+        async deletePortfolio({ commit }, portfolioId) {
+            try {
+                const data = await deletePortfolio(portfolioId);
+                commit('removePortfolio', portfolioId);
+            } catch (error) {
+                console.error('Error deleting portfolio:', error);
+            }
+        },
+    },
+
+    getters: {
+        portfolioList: (state) => state.portfolioList,
+        portfolioDetail: (state) => state.portfolioDetail,
+        newPortfolio: (state) => state.newPortfolio,
+        isPortfolioListLoaded: (state) => state.portfolioListLoaded,
+    },
+
+    mutations: {
+        setPortfolioList(state, portfolioList) {
+            state.portfolioList = portfolioList;
+            state.portfolioListLoaded = true;
+        },
+
+        setPortfolioDetail(state, portfolioDetail) {
+            state.portfolioDetail = portfolioDetail;
+        },
+
+        setNewPortfolio(state, newPortfolio) {
+            state.newPortfolio = newPortfolio;
+            state.portfolioList.push(newPortfolio); // 새로운 포트폴리오 리스트에 추가
+        },
+
+        removePortfolio(state, portfolioId) {
+            state.portfolioList = state.portfolioList.filter(
+                (portfolio) => portfolio.id !== portfolioId
+            );
+        },
+    },
+};
+
+export default portfolioModule;

--- a/src/views/account/auth/Login.vue
+++ b/src/views/account/auth/Login.vue
@@ -49,39 +49,23 @@ export default {
     async handleLogin() {
       const { cookies } = useCookies();
       this.errorMessage = ''; // Reset error message
-
       try {
-        const response = await axios.post(
-          'http://localhost:8080/api/member/login',
-          {
-            memberID: this.memberID,
-            password: this.password,
-          }
-        );
-
+        const response = await axios.post('http://localhost:8080/api/member/login', {
+          memberID: this.memberID,
+          password: this.password,
+        });
         console.log('Login successful:', response.data);
-
         const user = {
           username: response.data.responseData.data.name,
           picture: response.data.responseData.data.picture, // Assuming your response has a picture field
         };
-
         const authHeader =
-          response.headers['authorization'] ||
-          response.headers['Authorization'];
+            response.headers['authorization'] || response.headers['Authorization'];
         const refreshToken =
-          response.headers['refresh-token'] ||
-          response.headers['Refresh-Token'];
-
+            response.headers['refresh-token'] || response.headers['Refresh-Token'];
         if (authHeader && refreshToken) {
-          cookies.set('Authorization', authHeader, {
-            secure: true,
-            sameSite: 'Lax',
-          });
-          cookies.set('Refresh-Token', refreshToken, {
-            secure: true,
-            sameSite: 'Lax',
-          });
+          cookies.set('Authorization', authHeader, { secure: true, sameSite: 'Lax' });
+          cookies.set('Refresh-Token', refreshToken, { secure: true, sameSite: 'Lax' });
           localStorage.setItem('user', JSON.stringify(user));
           this.$emit('login', user);
           this.$router.push('/');
@@ -103,11 +87,7 @@ export default {
 </script>
 <style scoped>
 .background-container {
-  background: linear-gradient(
-    to bottom right,
-    #a0e0d2,
-    #ffffff
-  ); /* Minty gradient background */
+  background: linear-gradient(to bottom right, #A0E0D2, #FFFFFF); /* Minty gradient background */
   min-height: 100vh; /* Full height for background */
   display: flex; /* Center login container vertically */
   justify-content: center; /* Center horizontally */
@@ -116,7 +96,7 @@ export default {
 .login-container {
   max-width: 400px; /* Decreased max width for a more compact box */
   padding: 40px; /* Adjusted padding */
-  background-color: #ffffff; /* Solid background for the login box */
+  background-color: #FFFFFF; /* Solid background for the login box */
   border-radius: 10px; /* Rounded corners */
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2); /* Slightly larger shadow */
   text-align: center;
@@ -124,7 +104,7 @@ export default {
 }
 h2 {
   margin-bottom: 20px;
-  color: #4db6ac; /* Title color */
+  color: #4DB6AC; /* Title color */
   font-size: 28px; /* Slightly larger title */
 }
 .form-group {
@@ -134,7 +114,6 @@ h2 {
   position: relative;
   margin-top: 10px;
 }
-
 input[type='text'],
 input[type='password'] {
   width: 100%;
@@ -145,11 +124,10 @@ input[type='password'] {
   box-sizing: border-box;
   transition: border-color 0.3s; /* Smooth transition on focus */
 }
-
 input[type='text']:focus,
 input[type='password']:focus {
   outline: none;
-  border-color: #4caf50; /* Focus border color */
+  border-color: #4CAF50; /* Focus border color */
 }
 label {
   position: absolute;
@@ -160,15 +138,14 @@ label {
   pointer-events: none;
   transition: 0.3s ease all;
 }
-
 input[type='text']:focus + label,
 input[type='password']:focus + label,
 label.active {
   top: -10px;
   left: 5px;
   font-size: 12px;
-  color: #4caf50; /* Active label color */
-  background-color: #ffffff; /* Match background */
+  color: #4CAF50; /* Active label color */
+  background-color: #FFFFFF; /* Match background */
   padding: 0 5px;
 }
 .button-container {
@@ -178,7 +155,7 @@ label.active {
   margin-top: 15px;
 }
 .login-btn {
-  background-color: #4db6ac; /* Minty button background */
+  background-color: #4DB6AC; /* Minty button background */
   color: white; /* Button text color */
   border: none; /* No border */
   padding: 12px 20px; /* Adjusted button padding */
@@ -188,7 +165,7 @@ label.active {
   cursor: pointer; /* Cursor pointer for button */
 }
 .login-btn:hover {
-  background-color: #399d91; /* Darker mint color on hover */
+  background-color: #399D91; /* Darker mint color on hover */
 }
 .link-container {
   text-align: right; /* Align the link to the right */
@@ -196,11 +173,11 @@ label.active {
 }
 .link {
   font-size: 12px; /* Smaller font size for the link */
-  color: #4db6ac; /* Minty link color */
+  color: #4DB6AC; /* Minty link color */
   text-decoration: underline; /* Underline the link */
 }
 .link:hover {
-  color: #399d91; /* Darker link color on hover */
+  color: #399D91; /* Darker link color on hover */
 }
 .error-message {
   color: red;

--- a/src/views/portfolio/PortfolioData.vue
+++ b/src/views/portfolio/PortfolioData.vue
@@ -158,7 +158,7 @@ export default {
     },
 
     fetchPortfolio() {
-      fetch("/api/portfolio/1")
+      fetch("/api/portfolio/details/1")
         .then((response) => response.json())
         .then((data) => {
           this.portfolio = data;

--- a/src/views/portfolio/PortfolioData.vue
+++ b/src/views/portfolio/PortfolioData.vue
@@ -1,4 +1,4 @@
-<template>
+<template> <!-- 포트폴리오 단일 페이지 -->
   <div>
     <h1>내 포트폴리오</h1>
     <ul>
@@ -9,8 +9,8 @@
         {{ portfolio.portfolioName }}
         <!-- 생성 일자(날짜, 시간) 데이터 타입을 숫자로 날라오면 날짜 시간으로 처리 -->
         {{ portfolio.creationDate }}
-        <!-- 포트폴리오 투자총액 
-         /총액에 * 기대 수익률을 한다면 투자손익 
+        <!-- 포트폴리오 투자총액
+         /총액에 * 기대 수익률을 한다면 투자손익
          /투자금액 + 투자손익 = 총 평가금액 -->
         {{ portfolio.total }}
         <!-- 포트폴리오 기대 수익률 -->
@@ -147,7 +147,7 @@ export default {
   },
   methods: {
     fetchPortfolioList() {
-      fetch('/api/portfolio')
+      fetch("/api/portfolio/list")
         .then((response) => response.json())
         .then((data) => {
           this.portfolioList = data;
@@ -158,7 +158,7 @@ export default {
     },
 
     fetchPortfolio() {
-      fetch('/api/portfolio/1')
+      fetch("/api/portfolio/1")
         .then((response) => response.json())
         .then((data) => {
           this.portfolio = data;

--- a/src/views/portfolio/PortfolioEx.vue
+++ b/src/views/portfolio/PortfolioEx.vue
@@ -17,7 +17,7 @@
     <h1>내 포트폴리오 구성 상품</h1>
     <ul>
       {{portfolioDetail}}
-<!--      <li v-for="item in portfolioDetail.portfolioItems" :key="item.productId">-->
+<!--      <li v-for="item in portfolioDetail.portfolioItems" :key="item.prnpmoductId">-->
 <!--        {{ item.portfolioItemId }}-->
 <!--        {{ item.portfolioId }}-->
 <!--        {{ item.productId }}-->

--- a/src/views/portfolio/PortfolioEx.vue
+++ b/src/views/portfolio/PortfolioEx.vue
@@ -1,0 +1,129 @@
+<template> <!-- 포트폴리오 API/module 분리 페이지 -->
+  <div>
+    <h1>내 포트폴리오</h1>
+    <ul>
+      <li v-for="portfolio in portfolioList" :key="portfolio.portfolioId">
+        {{ portfolio.portfolioId }}
+        {{ portfolio.portfolioName }}
+        {{ portfolio.creationDate }}
+        {{ portfolio.total }}
+        {{ portfolio.expectedReturn }}
+        {{ portfolio.riskLevel }}
+        {{ portfolio.memberNum }}
+        <button @click="handleDeletePortfolio(portfolio.portfolioId)">삭제</button>
+      </li>
+    </ul>
+
+    <h1>내 포트폴리오 구성 상품</h1>
+    <ul>
+      {{portfolioDetail}}
+<!--      <li v-for="item in portfolioDetail.portfolioItems" :key="item.productId">-->
+<!--        {{ item.portfolioItemId }}-->
+<!--        {{ item.portfolioId }}-->
+<!--        {{ item.productId }}-->
+<!--        {{ item.stockCode }}-->
+<!--        {{ item.amount }}-->
+<!--        {{ item.expectedReturn }}-->
+<!--        {{ item.productType }}-->
+<!--        {{ item.dailyPrice }}-->
+<!--      </li>-->
+    </ul>
+
+    <!-- 상품 추가 폼 -->
+    <div>
+      <h2>포트폴리오 추가</h2>
+
+      <!-- 포트폴리오 이름 입력 -->
+      <input v-model="newPortfolio.portfolioName" placeholder="포트폴리오 이름" />
+
+      <!-- 첫 번째 상품 항목 -->
+      <h3>첫 번째 상품</h3>
+      <input v-model.number="newPortfolioItems[0].productId" placeholder="상품 ID" />
+      <input v-model="newPortfolioItems[0].stockCode" placeholder="주식 코드" />
+      <input v-model.number="newPortfolioItems[0].amount" placeholder="상품 수량" />
+
+      <!-- 두 번째 상품 항목 -->
+      <h3>두 번째 상품</h3>
+      <input v-model.number="newPortfolioItems[1].productId" placeholder="상품 ID" />
+      <input v-model="newPortfolioItems[1].stockCode" placeholder="주식 코드" />
+      <input v-model.number="newPortfolioItems[1].amount" placeholder="상품 수량" />
+
+      <!-- 세 번째 상품 항목 -->
+      <h3>세 번째 상품</h3>
+      <input v-model.number="newPortfolioItems[2].productId" placeholder="상품 ID" />
+      <input v-model="newPortfolioItems[2].stockCode" placeholder="주식 코드" />
+      <input v-model.number="newPortfolioItems[2].amount" placeholder="상품 수량" />
+
+      <!-- 포트폴리오 추가 버튼 -->
+      <button @click="addPortfolio">포트폴리오 추가</button>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapActions, mapGetters } from "vuex";
+
+export default {
+  data() {
+    return {
+      newPortfolio: {
+        portfolioName: "",
+        portfolioItems: [],
+      },
+      newPortfolioItems: [
+        { productId: null, stockCode: "", amount: null },
+        { productId: null, stockCode: "", amount: null },
+        { productId: null, stockCode: "", amount: null },
+      ],
+    };
+  },
+  computed: {
+    ...mapGetters("portfolio", ["portfolioList", "portfolioDetail"]),
+  },
+  methods: {
+    ...mapActions("portfolio", ["fetchPortfolioList", "postPortfolio", "deletePortfolio"]),
+
+    async addPortfolio() {
+      if (this.newPortfolio.portfolioName.trim()) {
+        try {
+          await this.postPortfolio(this.newPortfolio);
+          this.resetNewPortfolio(); // 포트폴리오 추가 후 리셋
+        } catch (error) {
+          console.error("Error adding portfolio:", error);
+        }
+      } else {
+        alert("포트폴리오 이름을 입력해주세요.");
+      }
+    },
+
+    resetNewPortfolio() {
+      this.newPortfolio = {
+        portfolioName: "",
+        portfolioItems: [],
+      };
+      this.newPortfolioItems = [
+        { productId: null, stockCode: "", amount: null },
+        { productId: null, stockCode: "", amount: null },
+        { productId: null, stockCode: "", amount: null },
+      ]; // 초기화
+    },
+
+    async handleDeletePortfolio(portfolioId) {
+      if (confirm("정말 삭제하시겠습니까?")) {
+        try {
+          await this.deletePortfolio(portfolioId);
+        } catch (error) {
+          console.error("Error deleting portfolio:", error);
+        }
+      }
+    },
+  },
+  async mounted() {
+    try {
+      await this.fetchPortfolioList();
+    } catch (error) {
+      console.error("Error loading portfolio list:", error);
+    }
+  },
+};
+</script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -969,9 +969,9 @@ vue3-cookies@^1.0.6:
     vue "^3.0.0"
 
 vuetify@^3.0.0, vuetify@^3.7.0-beta.1:
-  version "3.7.0-beta.1"
-  resolved "https://registry.npmjs.org/vuetify/-/vuetify-3.7.0-beta.1.tgz"
-  integrity sha512-F6a+pSG7dLrU28sGlR8r4WMuBsLMprOsDpaywGopNrGk351Hs4AAhx/y88ROGUEf28yAPShSM86bPnD30xNyDw==
+  version "3.7.2"
+  resolved "https://registry.npmjs.org/vuetify/-/vuetify-3.7.2.tgz"
+  integrity sha512-q0WTcRG977+a9Dqhb8TOaPm+Xmvj0oVhnBJhAdHWFSov3HhHTTxlH2nXP/GBTXZuuMHDbBeIWFuUR2/1Fx0PPw==
 
 vuex@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
1. 포트폴리오 api 모듈과 store 모듈을 생성해서 기존 vue 페이지 script를 분리했습니다.
* api( :api/portfolio.js)는 백엔드 api 호출함수 모음 - index.js에 공통 엔드 포인트와 요청/응답 인터셉터 처리를 해둠
* store( :store/modules/portfolio.js)는 .vue에서 사용될 데이터, 함수, getter들 모음 - 잘 살펴보고 변수명, 함수명 그대로 쓰면 됨
* 데이터 test용 vue( :views/portfolio/PortfolioEx.vue) - 기존 vue 파일이랑 비교하면서 보세요

2. 요청/응답 인터셉터 추가
* api/index.js에 공통 엔드포인트 설정('http://localhost:8080/api')
* 요청/응답 인터셉터 추가해뒀으니 다른 api 모듈에서도 끌어다 쓰세요