### PR TITLE
fix: 장바구니 리스트에서 선택 시 2개씩 상품 들어가는 오류 해결

### DIFF
--- a/src/views/financialProducts/Cart.vue
+++ b/src/views/financialProducts/Cart.vue
@@ -47,11 +47,7 @@
                         <div class="col checkbox-column">
                             <input
                                 type="checkbox"
-                                :value="{
-                                    productId: item.productId,
-                                    productType: item.productType,
-                                }"
-                                v-model="selectedProducts"
+                                :checked="isSelected(item)"
                                 @change="handleSelectionChange($event, item)"
                                 class="product-checkbox"
                             />
@@ -201,12 +197,20 @@ export default {
             });
         };
 
+        const isSelected = (item) => {
+            return selectedProducts.value.some(
+                (product) => product.productId === item.productId
+            );
+        };
+
         const handleSelectionChange = (event, item) => {
             if (event.target.checked) {
-                selectedProducts.value.push({
-                    productId: item.productId,
-                    productType: item.productType,
-                });
+                if (!isSelected(item)) {
+                    selectedProducts.value.push({
+                        productId: item.productId,
+                        productType: item.productType,
+                    });
+                }
             } else {
                 selectedProducts.value = selectedProducts.value.filter(
                     (product) => product.productId !== item.productId
@@ -229,6 +233,7 @@ export default {
             isAuthenticated,
             authStore,
             itemsPerPage,
+            isSelected,
         };
     },
 };


### PR DESCRIPTION
1. 장바구니에서 선택 후 포트폴리오 구성하기로 이동 시 같은 상품이 2개씩 들어가는 오류 해결