### PR TITLE
Design: 헤더 디자인 정렬, 장바구니 페이지 디자인 포트폴리오 구성 요구사항 충족

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -127,11 +127,11 @@
         <div class="user-controls">
             <template v-if="isLoggedIn">
                 <div class="profile-info">
-                    <div class="usernames" @click="navigateToProfile">
+                    <button class="usernames" @click="navigateToProfile">
                         <i class="fa-solid fa-user-tie"></i>
                         <span class="username">{{ userProfile.username }}</span>
-                    </div>
-                    <button @click.stop="handleLogout">로그아웃</button>
+                    </button>
+                    <button class="logout-btn" @click.stop="handleLogout">로그아웃</button>
                 </div>
             </template>
 
@@ -285,7 +285,7 @@ nav {
 .menu {
     display: flex;
     justify-content: center;
-    gap: 120px;
+    /* gap: 120px; */
     align-items: center;
     width: 100%;
 }
@@ -293,6 +293,8 @@ nav {
 .menu-item {
     font-size: 24px;
     font-weight: bold;
+    flex-basis: 20%;
+    text-align: center;
 }
 
 .menu-item:hover {
@@ -316,8 +318,8 @@ nav {
     justify-content: space-around;
     max-width: 1200px;
     width: 55%;
-    position: relative;
-    left: 5px;
+    /* position: relative;
+    left: 5px; */
 }
 
 .dropdown-section {
@@ -325,6 +327,7 @@ nav {
     flex-direction: column;
     align-items: center;
     padding: 0 10px;
+    flex-basis: 20%;
     border-left: 1px solid #ddd;
     flex-grow: 1;
     flex-basis: 0;
@@ -368,6 +371,16 @@ nav {
     width: 100%;
 }
 
+/* 모든 버튼의 기본 스타일 */
+button {
+    font-size: 16px; /* 모든 버튼의 텍스트 크기를 일관되게 설정 */
+    padding: 8px 16px; /* 텍스트 크기에 맞게 패딩 설정 */
+    border-radius: 5px;
+    border: none;
+    cursor: pointer;
+    transition: background-color 0.2s, color 0.2s;
+}
+
 .user-controls {
     display: flex;
     align-items: center;
@@ -375,6 +388,7 @@ nav {
     position: absolute;
     right: 4%;
     width: 200px;
+    justify-content: flex-end;
 }
 
 .profile-info,
@@ -388,9 +402,11 @@ nav {
 
 .profile-info button,
 .login-btn,
-.signup-btn {
+.signup-btn,
+.logout-btn {
     padding: 8px 12px;
     height: 40px;
+    font-size: 16px;
     border-radius: 5px;
     border: none;
     cursor: pointer;
@@ -399,8 +415,13 @@ nav {
 
 .profile-info button:hover,
 .login-btn:hover,
-.signup-btn:hover {
+.signup-btn:hover,
+.logout-btn:hover {
     background-color: #7bd5c3;
     color: white;
+}
+
+.username {
+    font-size: 16px;
 }
 </style>

--- a/src/components/Modal/ModalStock.vue
+++ b/src/components/Modal/ModalStock.vue
@@ -23,7 +23,7 @@
                     <thead>
                         <tr>
                             <th style="width: 7%; text-align: center"></th>
-                            <th style="width: 15%; text-align: left">주식 코드</th>
+                            <th style="width: 15%; text-align: left">종목 코드</th>
                             <th style="width: 28%; text-align: left">종목명</th>
                             <th style="width: 15%; text-align: center">시장 구분</th>
                             <th style="width: 12%; text-align: right">전일비</th>

--- a/src/views/financialProducts/Cart.vue
+++ b/src/views/financialProducts/Cart.vue
@@ -31,18 +31,23 @@
 
             <div class="table-container">
                 <!-- 테이블 헤더 -->
-                <div class="header-row table-responsive">
-                    <div class="checkbox-column center">선택</div>
-                    <div class="sortable-header">상품 종류</div>
-                    <div class="sortable-header">상품 이름</div>
-                    <div class="sortable-header">제공자</div>
-                    <div class="sortable-header">기대 수익률</div>
-                    <div class="text-center"></div>
+                <div class="header-row">
+                    <div class="header-cell checkbox-column">선택</div>
+                    <div class="header-cell product-type">상품 종류</div>
+                    <div class="header-cell product-name">상품 이름</div>
+                    <div class="header-cell provider">제공자</div>
+                    <div class="header-cell expected-return">기대 수익률</div>
+                    <div class="header-cell text-center"></div>
                 </div>
                 <hr class="divider" />
 
                 <!-- 테이블 바디 -->
-                <div v-for="item in paginatedCart" :key="item.cartId" class="cart-item">
+                <div
+                    v-for="item in paginatedCart"
+                    :key="item.cartId"
+                    class="cart-item"
+                    @click="goToProductDetail(item.productId, item.productType, item.rsrvType)"
+                >
                     <div class="cart-item-row">
                         <div class="col checkbox-column">
                             <input
@@ -53,22 +58,20 @@
                             />
                         </div>
                         <div class="col product-type">
-                            <span>
-                                <span v-if="item.productType === 'S'">
-                                    {{ item.rsrvType === 'S' ? '적금' : '예금' }}
-                                </span>
-                                <span v-else-if="item.productType === 'B'">채권</span>
-                                <span v-else-if="item.productType === 'F'">펀드</span>
-                                <span v-else>기타</span>
-                            </span>
+                            {{ item.rsrvType === 'S' ? '적금' : '예금' }}
                         </div>
                         <div class="col product-name">{{ item.productName }}</div>
                         <div class="col provider">{{ item.provider }}</div>
-                        <div class="col expected-return">{{ item.expectedReturn }}%</div>
+                        <div
+                            class="col expected-return"
+                            :style="getColorStyle(item.expectedReturn)"
+                        >
+                            {{ item.expectedReturn }}%
+                        </div>
                         <div class="col text-center">
                             <button
                                 class="btn btn-danger cart-trashcanBtn"
-                                @click="removeFromCart(item.cartId)"
+                                @click.stop="removeFromCart(item.cartId)"
                                 aria-label="삭제"
                             >
                                 <i class="mdi mdi-delete mdi-24px"></i>
@@ -198,9 +201,7 @@ export default {
         };
 
         const isSelected = (item) => {
-            return selectedProducts.value.some(
-                (product) => product.productId === item.productId
-            );
+            return selectedProducts.value.some((product) => product.productId === item.productId);
         };
 
         const handleSelectionChange = (event, item) => {
@@ -219,6 +220,31 @@ export default {
             console.log('선택된 상품 목록:', selectedProducts.value);
         };
 
+        const goToProductDetail = (productId, productType, rsrvType = null) => {
+            const type = getProductTypeReturn(productType, rsrvType);
+            router.push(`/list/${productId}?productType=${type}`).then(() => {
+                window.location.reload();
+            });
+        };
+
+        const getProductTypeReturn = (productType, rsrvType) => {
+            switch (productType) {
+                case 'S':
+                    if (rsrvType != null) return 'saving';
+                    return 'deposit';
+                case 'F':
+                    return 'fund';
+                default:
+                    return 'bond';
+            }
+        };
+
+        function getColorStyle(value) {
+            return {
+                color: value > 0 ? 'red' : value < 0 ? 'blue' : 'black',
+            };
+        }
+
         return {
             cart,
             removeFromCart,
@@ -234,13 +260,16 @@ export default {
             authStore,
             itemsPerPage,
             isSelected,
+            goToProductDetail,
+            getProductTypeReturn,
+            getColorStyle,
         };
     },
 };
 </script>
 
 <style scoped>
-/* 전체 요소에 box-sizing 적용 */
+/* 기본 설정 */
 * {
     box-sizing: border-box;
 }
@@ -277,6 +306,7 @@ export default {
     }
 }
 
+/* 빈 장바구니 스타일 */
 .empty-cart {
     text-align: center;
     padding: 40px;
@@ -303,12 +333,13 @@ export default {
     text-decoration: underline;
 }
 
+/* 장바구니 카드 스타일 */
 .cart-card {
     padding: 40px;
     background-color: #fff;
     border: 1px solid #dee2e6;
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    border-radius: 0; /* border-radius 제거 */
+    border-radius: 8px;
 }
 
 .card-title-container {
@@ -334,12 +365,49 @@ export default {
     width: 100%;
 }
 
-/* 테이블 헤더 */
+/* 테이블 바디,헤더 공통 스타일 */
+.header-row .checkbox-column,
+.header-row .product-type,
+.header-row .provider,
+.header-row .expected-return,
+.cart-item-row .checkbox-column,
+.cart-item-row .product-type,
+.cart-item-row .provider,
+.cart-item-row .expected-return {
+    text-align: center;
+}
+
+.header-row .product-name,
+.cart-item-row .product-name {
+    text-align: left;
+}
+
+.header-row,
+.cart-item-row {
+    display: flex;
+    padding: 15px 0;
+    align-items: center;
+    border-bottom: 1px solid #dee2e6;
+    font-size: 16px;
+    background-color: #f8f9fa;
+}
+
+.header-row .header-cell,
+.cart-item-row .col {
+    display: flex;
+    align-items: center;
+    padding: 10px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* 테이블 헤더 스타일 */
 .header-row {
     display: flex;
     background-color: #f8f9fa;
     border-bottom: 2px solid #dee2e6;
-    padding: 20px 0; /* 행 높이 증가 */
+    padding: 20px 0;
     font-size: 18px;
     cursor: pointer;
 }
@@ -349,95 +417,68 @@ export default {
     align-items: center;
 }
 
-.header-row .checkbox-column {
-    flex: 0 0 15%; /* 1번째 열: 10% */
-    max-width: 15%;
+/* 열 너비 및 정렬 설정 */
+.header-row .checkbox-column,
+.cart-item-row .checkbox-column {
+    flex: 0 0 10%;
     text-align: center;
 }
 
-.header-row .sortable-header:nth-child(2) {
-    flex: 0 0 15%; /* 2번째 열: 15% */
-    max-width: 15%;
+.header-row .product-type,
+.cart-item-row .product-type {
+    flex: 0 0 15%;
     text-align: center;
 }
 
-.header-row .sortable-header:nth-child(3) {
-    flex: 0 0 30%; /* 3번째 열: 35% */
-    max-width: 30%;
+.header-row .product-name,
+.cart-item-row .product-name {
+    flex: 1; /* 가장 넓게 설정하여 남은 공간을 활용 */
+    text-align: left;
+}
+
+.header-row .provider,
+.cart-item-row .provider {
+    flex: 0 0 20%;
     text-align: center;
 }
 
-.header-row .sortable-header:nth-child(4) {
-    flex: 0 0 15%; /* 4번째 열: 15% */
-    max-width: 15%;
+.header-row .expected-return,
+.cart-item-row .expected-return {
+    flex: 0 0 15%;
+    text-align: right;
+}
+
+.header-row .text-center,
+.cart-item-row .text-center {
+    flex: 0 0 10%;
     text-align: center;
 }
 
-.header-row .sortable-header:nth-child(5) {
-    flex: 0 0 15%; /* 5번째 열: 15% */
-    max-width: 15%;
-    text-align: center;
-}
-
-.header-row .text-center {
-    flex: 0 0 10%; /* 6번째 열: 10% */
-    max-width: 10%;
-    text-align: center;
-}
-
-/* 테이블 바디 */
+/* 테이블 바디 스타일 */
 .cart-item-row {
     display: flex;
     padding: 20px 0;
     align-items: center;
     background-color: #fff;
-    border-radius: 0;
+    border-bottom: 1px solid #dee2e6;
 }
 
 .cart-item-row .col {
-    flex: 1;
     font-size: 16px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
 }
 
-/* 수정된 데이터 컬럼 너비: 헤더와 동일하게 설정 */
-.cart-item-row .checkbox-column {
-    flex: 0 0 15%; /* 헤더와 일치 */
-    max-width: 15%;
-    text-align: center;
-}
-
-.cart-item-row .product-type {
-    flex: 0 0 15%; /* 헤더와 일치 */
-    max-width: 15%;
-}
-
-.cart-item-row .product-name {
-    flex: 0 0 30%; /* 헤더와 일치 */
-    max-width: 30%;
-}
-
-.cart-item-row .provider {
-    flex: 0 0 15%; /* 헤더와 일치 */
-    max-width: 15%;
-}
-
-.cart-item-row .expected-return {
-    flex: 0 0 15%; /* 헤더와 일치 */
-    max-width: 15%;
-}
-
-.cart-item-row .text-center {
-    flex: 0 0 10%; /* 헤더와 일치 */
-    max-width: 10%;
-    text-align: center;
+/* 상품 이름 hover 효과 */
+.product-name:hover {
+    text-decoration: underline;
+    cursor: pointer;
 }
 
 /* 버튼 스타일 */
 .btn {
-    padding: 10px 20px; /* 버튼 높이 조정 */
+    padding: 10px 20px;
     font-size: 16px;
     border: none;
     border-radius: 4px;
@@ -450,21 +491,9 @@ export default {
     margin-right: 8px;
 }
 
-.pagination-btn {
-    background-color: #007bff;
-    color: white;
-}
-
-.pagination-btn:hover {
-    background-color: #0056b3;
-}
-
-.btn-primary:hover {
-    scale: 1.3;
-}
-
+.btn-primary:hover,
 .btn-secondary:hover {
-    scale: 1.3;
+    transform: scale(1.1);
 }
 
 .btn-danger {
@@ -476,28 +505,25 @@ export default {
     background-color: #c82333;
 }
 
+/* 삭제 버튼 스타일 */
 .cart-trashcanBtn {
-    width: 40px; /* 버튼의 너비 조정 */
-    height: 40px; /* 버튼의 높이 조정 */
-    display: flex; /* Flexbox 사용 */
-    justify-content: center; /* 수평 중앙 정렬 */
-    align-items: center; /* 수직 중앙 정렬 */
-    padding: 0; /* 패딩 제거 */
-    border: none; /* 테두리 제거 */
-    background-color: #dc3545; /* btn-danger 색상 */
-    color: white; /* 아이콘 색상 */
-    cursor: pointer; /* 마우스 포인터 변경 */
-    border-radius: 4px; /* 버튼의 둥근 모서리 */
+    width: 40px;
+    height: 40px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 0;
+    background-color: #dc3545;
+    color: white;
+    border-radius: 4px;
+    cursor: pointer;
 }
 
 .cart-trashcanBtn .mdi-delete {
-    font-size: 24px; /* 아이콘 크기 조정 */
-    margin: 0; /* 불필요한 마진 제거 */
-    padding: 0; /* 불필요한 패딩 제거 */
-    line-height: 1; /* 라인 높이 조정 */
+    font-size: 24px;
 }
 
-/* 페이지네이션 버튼 */
+/* 페이지네이션 스타일 */
 .pagination {
     display: flex;
     justify-content: center;
@@ -507,7 +533,7 @@ export default {
 }
 
 .pagination-btn {
-    padding: 10px 20px; /* 버튼 높이 조정 */
+    padding: 10px 20px;
     font-size: 16px;
     border: none;
     border-radius: 4px;
@@ -537,7 +563,7 @@ export default {
     .header-row,
     .cart-item-row {
         font-size: 16px;
-        padding: 15px 0; /* 행 높이 조정 */
+        padding: 15px 0;
     }
 
     .btn,
@@ -547,7 +573,7 @@ export default {
     }
 
     .cart-item-row .col {
-        padding: 0 15px; /* 데이터 레이블 간 간격 조정 */
+        padding: 0 15px;
     }
 }
 
@@ -559,7 +585,7 @@ export default {
     .header-row,
     .cart-item-row {
         font-size: 14px;
-        padding: 10px 0; /* 행 높이 조정 */
+        padding: 10px 0;
     }
 
     .btn,
@@ -569,7 +595,7 @@ export default {
     }
 
     .cart-item-row .col {
-        padding: 0 10px; /* 데이터 레이블 간 간격 조정 */
+        padding: 0 10px;
     }
 }
 </style>

--- a/src/views/portfolio/MakePortfolio.vue
+++ b/src/views/portfolio/MakePortfolio.vue
@@ -2,16 +2,17 @@
     <div id="wrap">
         <div id="wrap-center">
             <h1 class="header">포트폴리오 만들기</h1>
-            <div class="portfolio-name-container">
-                <label for="nameInput"><h3>포트폴리오 이름 :</h3></label>
-                <input
-                    type="text"
-                    v-model="portfolioName"
-                    id="nameInput"
-                    placeholder="포트폴리오 이름을 입력해주세요."
-                />
+            <div class="PortfolioNameProportion">
+                <div class="portfolio-name-container">
+                    <label for="nameInput"><h3>포트폴리오 이름 :</h3></label>
+                    <input
+                        type="text"
+                        v-model="portfolioName"
+                        id="nameInput"
+                        placeholder="포트폴리오 이름을 입력해주세요."
+                    />
+                </div>
             </div>
-
             <!-- 추천 포트폴리오 구성 비율 -->
             <div class="recommendProportion">
                 <div class="PortfolioChartsContainer">
@@ -104,7 +105,7 @@
                     <table class="table">
                         <thead>
                             <tr>
-                                <th>
+                                <th style="width: 10%">
                                     <div class="Product-filter">
                                         <select v-model="selectedCategory" class="styled-select">
                                             <option value="">상품 종류</option>
@@ -114,11 +115,11 @@
                                         </select>
                                     </div>
                                 </th>
-                                <th>상품명</th>
-                                <th>상품 정보</th>
-                                <th>수익률</th>
-                                <th>투자액</th>
-                                <th></th>
+                                <th style="width: 25%">상품명</th>
+                                <th style="width: 20%">상품 정보</th>
+                                <th style="width: 20%">수익률</th>
+                                <th style="width: 15%">투자액</th>
+                                <th style="width: 10%"></th>
                             </tr>
                         </thead>
                         <tbody>
@@ -132,20 +133,10 @@
                                             item.rates[0]?.rsrvType === 'null'
                                         "
                                     >
-                                        <td class="product-type-cell">
-                                            예금
-                                            <span
-                                                class="info-icon"
-                                                v-tooltip="
-                                                    '예금/적금의 경우 투자금액은 개월수 * 투자액으로 계산됩니다.'
-                                                "
-                                                >●</span
-                                            >
-                                        </td>
+                                        <td class="product-type-cell">예금</td>
                                         <td>{{ item.products[0]?.finPrdtNm }}</td>
                                         <td>
                                             은행명: {{ item.products[0]?.korCoNm }}<br />
-                                            <!-- 상품명 중복 제거 -->
                                             만기:
                                             <select
                                                 v-model="item.selectedTerm"
@@ -165,33 +156,40 @@
                                             {{ getDepositInterestRate(item, 'intrRateTypeNm') }}
                                             <br />
                                             기본 금리:
-                                            {{ getDepositInterestRate(item, 'intrRate') }}%
+                                            <span
+                                                :style="
+                                                    getColorStyle(
+                                                        getDepositInterestRate(item, 'intrRate')
+                                                    )
+                                                "
+                                            >
+                                                {{ getDepositInterestRate(item, 'intrRate') }}%
+                                            </span>
                                             <br />
                                             최고 금리:
-                                            {{ getDepositInterestRate(item, 'intrRate2') }}%
+                                            <span
+                                                :style="
+                                                    getColorStyle(
+                                                        getDepositInterestRate(item, 'intrRate2')
+                                                    )
+                                                "
+                                            >
+                                                {{ getDepositInterestRate(item, 'intrRate2') }}%
+                                            </span>
                                         </td>
                                     </template>
 
+                                    <!-- 적금 타입 -->
                                     <template
                                         v-if="
                                             item.productType === 'S' &&
                                             item.rates[0]?.rsrvType != 'null'
                                         "
                                     >
-                                        <td class="product-type-cell">
-                                            적금
-                                            <span
-                                                class="info-icon"
-                                                v-tooltip="
-                                                    '예금/적금의 경우 투자금액은 개월수 * 투자액으로 계산됩니다.'
-                                                "
-                                                >●</span
-                                            >
-                                        </td>
+                                        <td class="product-type-cell">적금</td>
                                         <td>{{ item.products[0]?.finPrdtNm }}</td>
                                         <td>
                                             은행명: {{ item.products[0]?.korCoNm }}<br />
-                                            <!-- 상품명 중복 제거 -->
                                             만기:
                                             <select
                                                 v-model="item.selectedTerm"
@@ -221,15 +219,30 @@
                                             </select>
                                         </td>
                                         <td>
-                                            <br />
                                             단리/복리:
                                             {{ getSavingInterestRate(item, 'intrRateTypeNm') }}
                                             <br />
                                             기본 금리:
-                                            {{ getSavingInterestRate(item, 'intrRate') }}%
+                                            <span
+                                                :style="
+                                                    getColorStyle(
+                                                        getSavingInterestRate(item, 'intrRate')
+                                                    )
+                                                "
+                                            >
+                                                {{ getSavingInterestRate(item, 'intrRate') }}%
+                                            </span>
                                             <br />
                                             최고 금리:
-                                            {{ getSavingInterestRate(item, 'intrRate2') }}%
+                                            <span
+                                                :style="
+                                                    getColorStyle(
+                                                        getSavingInterestRate(item, 'intrRate2')
+                                                    )
+                                                "
+                                            >
+                                                {{ getSavingInterestRate(item, 'intrRate2') }}%
+                                            </span>
                                         </td>
                                     </template>
 
@@ -239,10 +252,22 @@
                                         <td>{{ item.productNm }}</td>
                                         <td>회사명: {{ item.companyNm }}<br /></td>
                                         <td>
-                                            1개월 수익률: {{ item.yield1 }}%<br />
-                                            3개월 수익률: {{ item.yield3 }}%<br />
-                                            6개월 수익률: {{ item.yield6 }}%<br />
-                                            12개월 수익률: {{ item.yield12 }}%<br />
+                                            1개월 수익률:
+                                            <span :style="getColorStyle(item.yield1)"
+                                                >{{ item.yield1 }}%</span
+                                            ><br />
+                                            3개월 수익률:
+                                            <span :style="getColorStyle(item.yield3)"
+                                                >{{ item.yield3 }}%</span
+                                            ><br />
+                                            6개월 수익률:
+                                            <span :style="getColorStyle(item.yield6)"
+                                                >{{ item.yield6 }}%</span
+                                            ><br />
+                                            12개월 수익률:
+                                            <span :style="getColorStyle(item.yield12)"
+                                                >{{ item.yield12 }}%</span
+                                            ><br />
                                         </td>
                                     </template>
 
@@ -254,7 +279,13 @@
                                             발행: {{ item.bondIsurNm }}<br />
                                             만기일: {{ item.bondExprDt }}<br />
                                         </td>
-                                        <td>이자 지급 방식: {{ item.intPayCyclCtt }}<br /></td>
+                                        <td>
+                                            채권 금리:
+                                            <span :style="getColorStyle(item.bondSrfcInrt)"
+                                                >{{ item.bondSrfcInrt }} %</span
+                                            ><br />
+                                            이자 지급 방식: {{ item.intPayCyclCtt }}
+                                        </td>
                                     </template>
 
                                     <td>
@@ -265,6 +296,18 @@
                                             :placeholder="getPlaceholder(item)"
                                             class="styled-input"
                                         />
+                                        <span
+                                            v-if="
+                                                item.productType === 'S' &&
+                                                item.rates[0]?.rsrvType !== 'null'
+                                            "
+                                            class="info-icon"
+                                            v-tooltip="
+                                                '적금의 경우 투자금액은 (개월수 * 투자액)으로 계산됩니다.'
+                                            "
+                                        >
+                                            ●
+                                        </span>
                                     </td>
                                     <td>
                                         <button @click="removeItem(item)">삭제</button>
@@ -304,13 +347,13 @@
                     <table class="table">
                         <thead>
                             <tr>
-                                <th>주식 코드</th>
-                                <th>주식명</th>
-                                <th>카테고리</th>
-                                <th>종가</th>
-                                <th>수량</th>
-                                <th>총액</th>
-                                <th></th>
+                                <th style="width: 10%; text-align: center">종목 코드</th>
+                                <th style="width: 20%; text-align: center">종목명</th>
+                                <th style="width: 10%; text-align: center">카테고리</th>
+                                <th style="width: 10%; text-align: center">종가</th>
+                                <th style="width: 15%; text-align: center">수량</th>
+                                <th style="width: 25%; text-align: center">총액</th>
+                                <th style="width: 10%; text-align: center"></th>
                             </tr>
                         </thead>
                         <tbody>
@@ -320,11 +363,17 @@
                                     :key="stock.stockCode"
                                     class="stock-row"
                                 >
-                                    <td>{{ stock.stockCode }}</td>
-                                    <td>{{ stock.stockName }}</td>
-                                    <td>{{ stock.mrktCtg }}</td>
-                                    <td>{{ stock.clpr }}</td>
-                                    <td>
+                                    <td style="width: 10%; text-align: center">
+                                        {{ stock.stockCode }}
+                                    </td>
+                                    <td style="width: 20%; text-align: center">
+                                        {{ stock.stockName }}
+                                    </td>
+                                    <td style="width: 10%; text-align: center">
+                                        {{ stock.mrktCtg }}
+                                    </td>
+                                    <td style="width: 10%; text-align: center">{{ stock.clpr }}</td>
+                                    <td style="width: 15%; text-align: center">
                                         <input
                                             type="number"
                                             v-model.number="stock.quantity"
@@ -332,14 +381,16 @@
                                             placeholder="주식수"
                                         />
                                     </td>
-                                    <td>
+                                    <td style="width: 25%; text-align: center">
                                         {{
-                                            isNaN(stock.clpr * stock.quantity)
-                                                ? 0
-                                                : stock.clpr * stock.quantity
+                                            formatCurrency(
+                                                isNaN(stock.clpr * stock.quantity)
+                                                    ? 0
+                                                    : stock.clpr * stock.quantity
+                                            )
                                         }}원
                                     </td>
-                                    <td>
+                                    <td style="width: 10%; text-align: center">
                                         <button @click="removeStock(stock)">삭제</button>
                                     </td>
                                 </tr>
@@ -641,6 +692,13 @@ export default {
             return Number(value).toLocaleString();
         };
 
+        // 양수, 음수, 0 색깔 지정
+        function getColorStyle(value) {
+            return {
+                color: value > 0 ? 'red' : value < 0 ? 'blue' : 'black',
+            };
+        }
+
         const getPlaceholder = (item) => {
             switch (item.productType) {
                 case 'S':
@@ -887,12 +945,14 @@ export default {
             distinguish,
             user_preference,
             newPortfolio,
+            getColorStyle,
         };
     },
 };
 </script>
 
 <style scoped>
+/* Wrapper Styles */
 #wrap {
     width: 90%;
     background-color: #fff;
@@ -908,14 +968,21 @@ export default {
     border-radius: 8px;
 }
 
+/* Header Styles */
 .header {
+    width: 260px;
+    border-radius: 8px;
+    background-color: #b3ebe0;
     text-align: center;
     margin-bottom: 20px;
     font-weight: bold;
     font-size: 24px;
+    margin: 0 auto;
 }
 
+/* Portfolio Name Container */
 .portfolio-name-container {
+    width: 600px;
     display: flex;
     align-items: center;
     gap: 10px;
@@ -929,6 +996,11 @@ export default {
     flex: 1;
 }
 
+#nameInput {
+    width: 500px;
+}
+
+/* Button Styles */
 .v-btn {
     background-color: #4db6ac;
     color: white;
@@ -941,17 +1013,20 @@ export default {
     margin-top: 15px;
 }
 
+/* Section Styles */
 .recommendProportion,
 .ProductSelection,
-.MakePortfolio-stockList-section {
-    max-width: 1200px; /* 좌우 폭을 동일하게 설정 */
-    margin: 20px auto; /* 가운데 정렬 */
+.MakePortfolio-stockList-section,
+.PortfolioNameProportion {
+    max-width: 1200px;
+    margin: 20px auto;
     background-color: #fff;
     padding: 20px;
     border-radius: 8px;
     border: 1px solid #ddd;
 }
 
+/* Filter and Radio Button Styles */
 .Product-filter,
 .CharCheck-radio {
     display: flex;
@@ -960,8 +1035,10 @@ export default {
     margin-bottom: 15px;
 }
 
+/* Table Styles */
 .table-container {
-    max-height: 300px;
+    width: 100%;
+    max-height: 450px;
     overflow-y: auto;
 }
 
@@ -1003,10 +1080,7 @@ export default {
     border-radius: 4px;
 }
 
-.cart-btn {
-    margin-top: 20px;
-}
-
+/* Table Button Styles */
 .table button {
     padding: 5px 10px;
     background-color: #f44336;
@@ -1019,6 +1093,7 @@ export default {
     background-color: #d32f2f;
 }
 
+/* Investment Amount and Proportion Calculations */
 .totalInvestmentAmount {
     margin-top: 20px;
     text-align: right;
@@ -1032,6 +1107,7 @@ export default {
     justify-content: space-between;
 }
 
+/* Styled Select and Input */
 .styled-select,
 .styled-input {
     padding: 5px;
@@ -1039,12 +1115,13 @@ export default {
     border-radius: 4px;
 }
 
+/* Portfolio Chart and Real-Time Proportion Chart */
 .PortfolioChartsContainer {
     width: 100%;
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    gap: 20px; /* 차트 간 간격 조정 */
+    gap: 20px;
 }
 
 .PortfolioChart,
@@ -1057,7 +1134,7 @@ export default {
 
 .title-container {
     width: 100%;
-    text-align: left; /* 제목만 왼쪽 정렬 */
+    text-align: left;
 }
 
 .chart-container {
@@ -1070,6 +1147,7 @@ export default {
     flex: 1;
 }
 
+/* Additional Layouts */
 .last-row {
     display: flex;
 }
@@ -1078,8 +1156,9 @@ export default {
     margin-top: 20px;
 }
 
+/* Tooltip Styles */
 .info-icon {
-    font-size: 0.9em; /* 작은 동그라미 크기 설정 */
+    font-size: 0.9em;
     color: #bb3434;
     margin-left: 5px;
     cursor: pointer;


### PR DESCRIPTION
Design: 헤더 디자인 정렬, 장바구니 페이지 디자인 포트폴리오 구성 요구사항 충족
ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ
헤더 : menu-item 과 dropdown-section 맞춤. 로그인/회원가입, 유저정보/로그아웃 버튼 셋 위치 정렬.

장바구니 : 상품명 클릭 시 상세로 이동, 데이터 테이블 정보 표시되게 정렬, 수익률 빨/파 색깔 적용.

포트폴리오 구성: 
    주식 코드 주식명 -> 종목' '으로
    주식 부분 총액 너비 고정
    빨간버튼 금액입력란 뒤에 배치(적금만)
    이름 입력란 주변 border,
    이름 입력칸 줄이기,
    주식 담은 테이블 삭제 버튼 위 헤더 설정
    금융상품 테이블 쪽 퍼센트 관련 style 지정(빨/파) -> 헤더이름 일단 수익률로

